### PR TITLE
Ignore elm-stuff directory

### DIFF
--- a/src/eslint/config.ts
+++ b/src/eslint/config.ts
@@ -25,6 +25,7 @@ function getConfig(options: Options): Config {
       '**/node_modules/**',
       '**/bower_components/**',
       '**/flow-typed/**',
+      '**/elm-stuff/**',
       '**/*.min.js',
       '**/bundle.js',
       '{tmp,temp}/**',

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -17,6 +17,7 @@ const baseESLintConfig = {
     '**/node_modules/**',
     '**/bower_components/**',
     '**/flow-typed/**',
+    '**/elm-stuff/**',
     '**/*.min.js',
     '**/bundle.js',
     '{tmp,temp}/**',


### PR DESCRIPTION
Ignoring `elm-stuff` which is the pendant to `node_modules` for elm projects.